### PR TITLE
Example code: Queries over state

### DIFF
--- a/src/Main.mo
+++ b/src/Main.mo
@@ -1,7 +1,50 @@
 import Types "Types";
 import State "State";
 
-actor {
-  // to do
-  // -- See Types and State modules
+import Buffer "mo:base/Buffer";
+
+shared ({caller = initPrincipal})
+actor class Service() {
+
+  var state : State.State = State.empty({admin = initPrincipal});
+
+  func getUserPosts_(caller : Principal, user : Types.Bare) : ?[Types.Post.Post] {
+    do ? {
+      let postIds = state.userPosts.get0({user});
+      let posts = Buffer.Buffer<Types.Post.Post>(0);
+      for (p in postIds.vals()) {
+        posts.add(state.posts.get(p)!)
+      };
+      posts.toArray()
+    }
+  };
+
+  func getUserSummary_(caller : Principal, user : Types.Bare) : ?Types.User.Summary {
+    // to do -- protect with access control, using msg.caller
+    do ? {
+      let userData = state.users.get({user})!;
+      {
+        user;
+        name = userData.name;
+        createTime = userData.createTime;
+      }
+    }
+  };
+
+  public query(msg) func getUserSummary(user : Types.Bare) : async ?Types.User.Summary {
+    getUserSummary_(msg.caller, user)
+  };
+
+  public query(msg) func getUserFull(user : Types.Bare) : async ?Types.User.Full {
+    do ? {
+      let summary = getUserSummary_(msg.caller, user)!;
+      let posts = getUserPosts_(msg.caller, user)!;
+      {
+        summary;
+        posts;
+      }
+    }
+  };
+
+
 }

--- a/src/Types.mo
+++ b/src/Types.mo
@@ -54,13 +54,13 @@ module {
     /// Summarizes basic profile info.
     public type Summary = {
       user : Bare;  // or User.Id, to be more specific. But then user.user is annoying, so this.
+      name : Text;
       createTime : Time;
-      username : Text;
     };
     /// Data for user to be stored in DB, each keyed by an Id.
     public type User = {
+      name : Text;
       createTime : Time;
-      username : Text;
     };
     /// Full -- A user's "full data' is defined by their posts, in aggregate?
     ///


### PR DESCRIPTION
This codebase is heavily based on CanCan, whose patterns it reuses.

However, it uses the Motoko type system more in its description of entity Ids, where they have distinct types.

As I had hoped, I think that extra type information is helping me avoid easy-to-make errors, like doing `get0` rather than `get1` on a binary relation and then mis-using the resulting array of keys somehow.

This PR shows an example of this exact pattern, where I initially wrote the wrong `get` version, but the type system prevented it from type-checking.